### PR TITLE
Feature/theme as module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "themes/candor-hugo-theme"]
+	path = themes/candor-hugo-theme
+	url = https://github.com/diletta-ci/candor-hugo-theme.git

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 baseurl = "https://diletta.dev/"
 title = "Diletta"
-theme = "PaperMod"
+theme = "candor"
 defaultContentLanguage = "it"
 
 [Params]

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 baseurl = "https://diletta.dev/"
 title = "Diletta"
-theme = "candor"
+theme = "candor-hugo-theme"
 defaultContentLanguage = "it"
 
 [Params]


### PR DESCRIPTION
## What
Export theme in a [different repo](https://github.com/diletta-ci/candor-hugo-theme) and use it as submodule.

## Why
Keep theme separate from site code, for better readability and clarity. 